### PR TITLE
Optional input_oois: use "None" for hash

### DIFF
--- a/scheduler/models/boefje.py
+++ b/scheduler/models/boefje.py
@@ -22,7 +22,7 @@ class BoefjeMeta(BaseModel):
 
     id: str
     boefje: Boefje
-    input_ooi: str
+    input_ooi: Optional[str]
     arguments: Dict[str, Any]
     organization: str
     started_at: Optional[datetime.datetime]

--- a/scheduler/models/tasks.py
+++ b/scheduler/models/tasks.py
@@ -109,4 +109,3 @@ class BoefjeTask(BaseModel):
             return mmh3.hash_bytes(f"{self.input_ooi}-{self.boefje.id}-{self.organization}").hex()
 
         return mmh3.hash_bytes(f"{self.boefje.id}-{self.organization}").hex()
-

--- a/scheduler/models/tasks.py
+++ b/scheduler/models/tasks.py
@@ -92,7 +92,7 @@ class BoefjeTask(BaseModel):
 
     id: str = Field(default_factory=lambda: uuid.uuid4().hex)
     boefje: Boefje
-    input_ooi: str
+    input_ooi: Optional[str]
     organization: str
 
     dispatches: List[Normalizer] = Field(default_factory=list)
@@ -105,4 +105,6 @@ class BoefjeTask(BaseModel):
         """Make BoefjeTask hashable, so that we can de-duplicate it when used
         in the PriorityQueue. We hash the combination of the attributes
         input_ooi and boefje.id since this combination is unique."""
-        return mmh3.hash_bytes(f"{self.input_ooi}-{self.boefje.id}-{self.organization}").hex()
+        input_ooi = self.input_ooi if self.input_ooi else "None"
+
+        return mmh3.hash_bytes(f"{input_ooi}-{self.boefje.id}-{self.organization}").hex()

--- a/scheduler/models/tasks.py
+++ b/scheduler/models/tasks.py
@@ -105,6 +105,8 @@ class BoefjeTask(BaseModel):
         """Make BoefjeTask hashable, so that we can de-duplicate it when used
         in the PriorityQueue. We hash the combination of the attributes
         input_ooi and boefje.id since this combination is unique."""
-        input_ooi = self.input_ooi if self.input_ooi else "None"
+        if self.input_ooi:
+            return mmh3.hash_bytes(f"{self.input_ooi}-{self.boefje.id}-{self.organization}").hex()
 
-        return mmh3.hash_bytes(f"{input_ooi}-{self.boefje.id}-{self.organization}").hex()
+        return mmh3.hash_bytes(f"{self.boefje.id}-{self.organization}").hex()
+


### PR DESCRIPTION
This PR makes the `input_ooi` field optional.

Relates to:
- https://github.com/minvws/nl-kat-bytes/pull/20
- https://github.com/minvws/nl-kat-boefjes/pull/39
- https://github.com/minvws/nl-kat-bytes/pull/20

## Consequences

This has effect on the has that is created for `BoefjeTask`s, for which I use the string "None" now. I am open to better suggestions (perhaps just leave it out completely, i.e. "None-some-boefjes..." -> "some-boefje"?).

Such tasks will also not be scheduled automatically by the scheduler, as this is done by randomly fetching OOIs or finding new ones to schedule boefjes on. However, the boefjes that require this feature so far do the scheduling themselves, so perhaps this behaviour is desirable.

@jpbruinsslot Do you see other issues with this change? 